### PR TITLE
fix: only send merge_fields param when merge fields are actually call…

### DIFF
--- a/library/HelloSign/Template.php
+++ b/library/HelloSign/Template.php
@@ -381,8 +381,10 @@ class Template extends AbstractResource
                 unset($params[$key]);
             }
         }
-
-        $params['merge_fields'] = $merge_fields;
+        
+        if (isset($merge_fields)){
+          $params['merge_fields'] = $merge_fields;          
+        }
 
         return $params;
     }


### PR DESCRIPTION
`merge_fields` is an optional parameter. It's getting sent regardless of whether merge fields are actually being specified or not. see issue #9 
