### PR TITLE
fix problem with not sending merge_fields parameter as blank

### DIFF
--- a/library/HelloSign/Template.php
+++ b/library/HelloSign/Template.php
@@ -370,7 +370,7 @@ class Template extends AbstractResource
             'use_preexisting_fields'
         );
 
-        if(isset($this->merge_fields)){
+        if(isset($this->merge_fields) && count($this->merge_fields) > 0){
             $merge_fields = json_encode($this->merge_fields);
         }
 


### PR DESCRIPTION
Related to issue #9, it looks like the previous pull request didn't go quite far enough, since `$this->merge_fields` is initialized as an array. If you could pull this in, that would be great. thanks!
