### PR TITLE
Update SignatureRequest to add custom_fields

### DIFF
--- a/library/HelloSign/Client.php
+++ b/library/HelloSign/Client.php
@@ -41,7 +41,7 @@ use Comvi\REST;
 class Client
 {
 
-    const VERSION = '3.5.2';
+    const VERSION = '3.5.3';
 
     const API_URL = "https://api.hellosign.com/v3/";
 

--- a/library/HelloSign/SignatureRequest.php
+++ b/library/HelloSign/SignatureRequest.php
@@ -166,7 +166,28 @@ class SignatureRequest extends AbstractSignatureRequest
         return $this;
     }
     
-    
+    /**
+     * Set the value for a custom field with the given field name
+     * and optionally define a Role allowed to edit it and if the field is required to be filled
+     *
+     * @param  string $field_name field name to be filled in
+     * @param  string $value
+     * @param  string $editor
+     * @param  string $required
+     * @return SignatureRequest
+     */
+    public function setCustomFieldValue($field_name, $value, $editor = null, $required = null)
+    {
+        $custom_fields = isset($this->custom_fields) ? json_decode($this->custom_fields) : array();
+        $custom_fields[] = array(
+            'name'     => $field_name,
+            'value'    => $value,
+            'editor'   => $editor,
+            'required'   => $required
+        );
+        $this->custom_fields = json_encode($custom_fields);
+        return $this;
+    }
 
     /**
      * @param  string $email
@@ -195,7 +216,6 @@ class SignatureRequest extends AbstractSignatureRequest
             'files_url',
             'signing_url',
             'details_url',
-            'custom_fields',
             'response_data',
             'signatures'
         ));


### PR DESCRIPTION
This update allows custom_fields to be passed for text_tags (and eventually form_fields_per_document).