### PR TITLE
Enable HTTP Configuration of Guzzle Client

### DIFF
--- a/library/HelloSign/Client.php
+++ b/library/HelloSign/Client.php
@@ -676,10 +676,13 @@ class Client
      */
     public function requestOAuthToken(OAuthTokenRequest $request, $auto_set_request_token = false)
     {
-        $rest = new REST(array(
-            'server' => $this->oauth_token_url,
-            'debug_mode' => $this->debug_mode
-        ));
+        $rest = new REST(
+                array(
+                'server' => $this->oauth_token_url,
+                'debug_mode' => $this->debug_mode
+            ),
+            $this->http_client_config
+        );
 
         if ($this->oauth_token_url != self::OAUTH_TOKEN_URL) {
             $this->disableCertificateCheck($rest);
@@ -712,10 +715,13 @@ class Client
      */
     public function refreshOAuthToken(OAuthToken $token, $auto_set_request_token = false)
     {
-        $rest = new REST(array(
-            'server' => $this->oauth_token_url,
-            'debug_mode' => $this->debug_mode
-        ));
+        $rest = new REST(
+                array(
+                'server' => $this->oauth_token_url,
+                'debug_mode' => $this->debug_mode
+            ),
+            $this->http_client_config
+        );
 
         if ($this->oauth_token_url != self::OAUTH_TOKEN_URL) {
             $this->disableCertificateCheck($rest);

--- a/library/HelloSign/Client.php
+++ b/library/HelloSign/Client.php
@@ -107,9 +107,9 @@ class Client
     /**
      * HTTP client configuration via the Guzzle library specification
      *
-     * @var array $rest_client_config
+     * @var array $http_client_config
      */
-    protected $rest_client_config = array();
+    protected $http_client_config = array();
 
     /**
      * Enable debug mode or not
@@ -124,12 +124,12 @@ class Client
      * @param  mixed $first email address or apikey or OAuthToken
      * @param  string $last Null if using apikey or OAuthToken
      * @param  string $api_url (optional) alternative api base url
-     * @param  array $rest_client_config (optional) configuration for the http client
+     * @param  array $http_client_config (optional) configuration for the http client
      */
-    public function __construct($first, $last = null, $api_url = self::API_URL, $oauth_token_url = self::OAUTH_TOKEN_URL, $rest_client_config = array())
+    public function __construct($first, $last = null, $api_url = self::API_URL, $oauth_token_url = self::OAUTH_TOKEN_URL, $http_client_config = array())
     {
         $this->oauth_token_url = $oauth_token_url;
-        $this->rest_client_config = $rest_client_config;
+        $this->http_client_config = $http_client_config;
         $this->rest = $this->createREST($first, $last, $api_url);
         $this->rest->setHeader('User-Agent', 'hellosign-php-sdk/' . self::VERSION);
     }
@@ -1032,7 +1032,7 @@ class Client
                 'pass'   => $last,
                 'debug_mode' => $this->debug_mode
             ),
-            $this->rest_client_config
+            $this->http_client_config
         );
     }
 

--- a/library/HelloSign/Client.php
+++ b/library/HelloSign/Client.php
@@ -1015,10 +1015,13 @@ class Client
     protected function createREST($first, $last = null, $api_url = self::API_URL)
     {
         if ($first instanceof OAuthToken) {
-            $rest = new REST(array(
-                'server' => $api_url,
-                'debug_mode' => $this->debug_mode
-            ));
+            $rest = new REST(
+                    array(
+                    'server' => $api_url,
+                    'debug_mode' => $this->debug_mode
+                ),
+                $this->http_client_config
+            );
             $auth = $first->getTokenType() . ' ' . $first->getAccessToken();
             $rest->setHeader('Authorization', $auth);
 

--- a/library/HelloSign/Client.php
+++ b/library/HelloSign/Client.php
@@ -105,6 +105,13 @@ class Client
     protected $rest;
 
     /**
+     * HTTP client configuration via the Guzzle library specification
+     *
+     * @var array $rest_client_config
+     */
+    protected $rest_client_config = array();
+
+    /**
      * Enable debug mode or not
      *
      * @var boolean
@@ -117,10 +124,12 @@ class Client
      * @param  mixed $first email address or apikey or OAuthToken
      * @param  string $last Null if using apikey or OAuthToken
      * @param  string $api_url (optional) alternative api base url
+     * @param  array $rest_client_config (optional) configuration for the http client
      */
-    public function __construct($first, $last = null, $api_url = self::API_URL, $oauth_token_url = self::OAUTH_TOKEN_URL)
+    public function __construct($first, $last = null, $api_url = self::API_URL, $oauth_token_url = self::OAUTH_TOKEN_URL, $rest_client_config = array())
     {
         $this->oauth_token_url = $oauth_token_url;
+        $this->rest_client_config = $rest_client_config;
         $this->rest = $this->createREST($first, $last, $api_url);
         $this->rest->setHeader('User-Agent', 'hellosign-php-sdk/' . self::VERSION);
     }
@@ -1016,12 +1025,15 @@ class Client
             return $rest;
         }
 
-        return new REST(array(
-            'server' => $api_url,
-            'user'   => $first,
-            'pass'   => $last,
-            'debug_mode' => $this->debug_mode
-        ));
+        return new REST(
+            array(
+                'server' => $api_url,
+                'user'   => $first,
+                'pass'   => $last,
+                'debug_mode' => $this->debug_mode
+            ),
+            $this->rest_client_config
+        );
     }
 
     /**

--- a/library/lib/REST.php
+++ b/library/lib/REST.php
@@ -69,17 +69,17 @@ class REST
     protected $mime_type;
 
 
-    function __construct($config = array())
+    function __construct($config = array(), $options = array())
     {
         // If a URL was passed to the library
         empty($config) OR $this->initialize($config);
 
-        $options = ['connect_timeout' => 300.0, 'timeout' => 30.0, 'allow_redirects' => true];
+        $default_options = ['connect_timeout' => 300.0, 'timeout' => 30.0, 'allow_redirects' => true];
         if (!empty($this->server)) {
-            $options['base_uri'] = $this->server;
+            $default_options['base_uri'] = $this->server;
         }
 
-        $this->guzzleClient = new \GuzzleHttp\Client($options);
+        $this->guzzleClient = new \GuzzleHttp\Client(array_merge($default_options, $options));
     }
 
     public function initialize($config)

--- a/library/lib/REST.php
+++ b/library/lib/REST.php
@@ -69,17 +69,17 @@ class REST
     protected $mime_type;
 
 
-    function __construct($config = array(), $options = array())
+    function __construct($config = array(), $http_options = array())
     {
         // If a URL was passed to the library
         empty($config) OR $this->initialize($config);
 
-        $default_options = ['connect_timeout' => 300.0, 'timeout' => 30.0, 'allow_redirects' => true];
+        $default_http_options = ['connect_timeout' => 300.0, 'timeout' => 30.0, 'allow_redirects' => true];
         if (!empty($this->server)) {
-            $default_options['base_uri'] = $this->server;
+            $default_http_options['base_uri'] = $this->server;
         }
 
-        $this->guzzleClient = new \GuzzleHttp\Client(array_merge($default_options, $options));
+        $this->guzzleClient = new \GuzzleHttp\Client(array_merge($default_http_options, $http_options));
     }
 
     public function initialize($config)


### PR DESCRIPTION
This PR enables an optional parameter to pass Guzzle configuration into the `HelloSign\Client` constructor. In turn, this passes the configuration down to the customized `REST` whenever one of these objects is created.

Our use case for this functionality is to enable web proxies, but this also allows full Guzzle configuration which has a number of benefits.

These changes should not have any adverse effects on current usage and are backward compatible.