### PR TITLE
Fixed return type of getType() method in Event class

### DIFF
--- a/library/HelloSign/Event.php
+++ b/library/HelloSign/Event.php
@@ -118,7 +118,7 @@ class Event extends AbstractResource
     }
 
     /**
-     * @return integer
+     * @return string
      * @ignore
      */
     public function getType()


### PR DESCRIPTION
Fixed the return type in the DocBlock of the getType() method from integer to string.