### PR TITLE
Updated Client::getSignatureRequests() to accept page size, and search query

### DIFF
--- a/library/HelloSign/Client.php
+++ b/library/HelloSign/Client.php
@@ -496,14 +496,19 @@ class Client
      * Retrieves the current user's signature requests. The resulting object
      * represents a paged query result.
      *
-     * @param  Integer $page
+     * @param int $page
+     * @param int $pageSize
+     * @param null|string $query
      * @return SignatureRequestList
      * @throws BaseException
+     * @throws Error
      */
-    public function getSignatureRequests($page = 1)
+    public function getSignatureRequests($page = 1, $pageSize = 20, $query = null)
     {
         $params = array(
-            'page' => $page
+            'page' => $page,
+            'page_size' => $pageSize,
+            'query' => $query,
         );
 
         $response = $this->rest->get(


### PR DESCRIPTION
This should be backwards compatible with existing implementations. I can also add logic flows to only add `query` to the `$params` array if `$query` has a non-null value if that is desired. I can also change the docblock to use `Integer` instead of `int` if this will be a consistency concern.