### PR TITLE
Add merge_field support to embedded template editing

### DIFF
--- a/library/HelloSign/Template.php
+++ b/library/HelloSign/Template.php
@@ -545,12 +545,19 @@ class Template extends AbstractResource
             'skip_subject_message'
         );
 
+        if (isset($this->merge_fields) && count($this->merge_fields) > 0) {
+            $merge_fields = json_encode($this->merge_fields);
+        }
         $params = $this->toArray();
 
         foreach ($params as $key => $value) {
             if (!in_array($key, $fields_to_include)) {
                 unset($params[$key]);
             }
+        }
+
+        if (isset($merge_fields)) {
+            $params['merge_fields'] = $merge_fields;
         }
 
         return $params;


### PR DESCRIPTION
Per the API documentation entry for embedded templates (https://app.hellosign.com/api/embeddedTemplatesWalkthrough#EmbeddedTemplatesEditingATemplate), the API supports passing a `merge_fields` property when retrieving a embedded template's `edit_url`. However, adding merge fields to the Template object and passing the Template object to the `Client::getEmbeddedEditUrl()` method did not result in a change to the template's merge fields. This PR adds support for changing merge_fields when updating an embedded template.

The `merge_fields` change act as an atomic update in that ALL fields (both existing **and** new) must be included in the `merge_fields` JSON string. This appears to be the intended functionality as I experienced this when issuing a cURL command directly to the API.

According to PHPStorm, the only usages of the `Template::toParams()` method is in the `Client::getEmbeddedEditUrl()` method so this likely has low-to-no impact anywhere else. The code snippet is exactly the same as the handling of the `Template::merge_fields` property in the `Template::toEmbeddedDraftParams()` method. Thus, the code isn't very DRY. However, all of the `toXxParams()` methods in the `Template` class aren't very dry. If you like, I will amend this PR so that the various `toXxParams()` methods all use a single method to generate the valid parameter array.