### PR TITLE
Update Legacy SDK to Support Preview

### DIFF
--- a/legacy/library/HelloSignLegacy/Template.php
+++ b/legacy/library/HelloSignLegacy/Template.php
@@ -202,6 +202,14 @@ class Template extends AbstractResource
    protected $allow_reassign = false;
 
     /**
+     * Specifies whether or not to allow the requester to enable the editor/preview experience.
+     *
+     * Defaults to false.
+     * @var boolean
+     */
+    protected $show_preview = false;
+
+    /**
      * @return string
      * @ignore
      */
@@ -423,6 +431,16 @@ class Template extends AbstractResource
      * @return Template
      * @ignore
      */
+    public function enableShowPreview()
+    {
+        $this->show_preview = true;
+        return $this;
+    }
+
+    /**
+     * @return Template
+     * @ignore
+     */
     public function disableAllowReassign()
     {
         $this->allow_reassign = false;
@@ -510,7 +528,8 @@ class Template extends AbstractResource
             'metadata',
             'skip_me_now',
             'allow_reassign',
-            'attachments'
+            'attachments',
+            'show_preview',
         );
 
         if (isset($this->merge_fields) && count($this->merge_fields) > 0) {

--- a/legacy/library/HelloSignLegacy/TemplateSignatureRequest.php
+++ b/legacy/library/HelloSignLegacy/TemplateSignatureRequest.php
@@ -57,6 +57,23 @@ class TemplateSignatureRequest extends AbstractSignatureRequest
     protected $ccs = array();
 
     /**
+     * Specifies whether or not to allow the requester to enable the editor/preview experience.
+     *
+     * Defaults to false.
+     * @var boolean
+     */
+    protected $show_preview = false;
+
+    /**
+     * Specifies whether or not to allow the requester to enable the preview experience experience.
+     * Note: This parameter overwrites show_preview=1 (if set).
+     *
+     * Defaults to false.
+     * @var boolean
+     */
+    protected $preview_only = false;
+
+    /**
      * Set the template ID, along with an optional order
      * @param string $id
      * @param int null $index
@@ -100,6 +117,24 @@ class TemplateSignatureRequest extends AbstractSignatureRequest
 
         $this->ccs[$role] = $obj;
 
+        return $this;
+    }
+
+    /**
+     * @return TemplateSignatureRequest
+     */
+    public function enableShowPreview()
+    {
+        $this->show_preview = true;
+        return $this;
+    }
+
+    /**
+     * @return TemplateSignatureRequest
+     */
+    public function enablePreviewOnly()
+    {
+        $this->preview_only = true;
         return $this;
     }
 

--- a/legacy/library/HelloSignLegacy/UnclaimedDraft.php
+++ b/legacy/library/HelloSignLegacy/UnclaimedDraft.php
@@ -87,6 +87,14 @@ class UnclaimedDraft extends AbstractSignatureRequestWrapper
     protected $skip_me_now = false;
 
     /**
+     * Specifies whether or not to allow the requester to enable the editor/preview experience.
+     *
+     * Defaults to false.
+     * @var boolean
+     */
+    protected $show_preview = false;
+
+    /**
      * @param  boolean $is_for_embedded_signing
      * @return UnclaimedDraft
      * @ignore
@@ -116,6 +124,16 @@ class UnclaimedDraft extends AbstractSignatureRequestWrapper
     public function enableSkipMeNow()
     {
         $this->skip_me_now = true;
+        return $this;
+    }
+
+    /**
+     * @return UnclaimedDraft
+     * @ignore
+     */
+    public function enableShowPreview()
+    {
+        $this->show_preview = true;
         return $this;
     }
 


### PR DESCRIPTION
Updated the following endpoints to support preview:

1. /unclaimed_draft/create_embedded_with_template add support for `show_preview` and `preview_only`
2. /unclaimed_draft/create_embedded  add support for `show_preview`
3. /template/create_embedded_draft  add support for `show_preview` 